### PR TITLE
Update pom.xml with source file encoding and plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,9 @@
     <version>1.1</version>
     <name>simpleAnnotationStore Maven Webapp</name>
     <url>http://maven.apache.org</url>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>javax.servlet</groupId>
@@ -111,6 +114,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.19.1</version>
                 <configuration>
                     <excludes>
                         <!--<exclude>**/TestPublish.java</exclude>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -12,56 +12,56 @@
         <filter-name>CorsFilter</filter-name>
         <url-pattern>/*</url-pattern>
     </filter-mapping>
-	<servlet>
-		<servlet-name>InitServer</servlet-name>
-		<servlet-class>uk.org.llgc.annotation.store.StoreConfig</servlet-class>
-	    <!--<init-param>
-	        <param-name>store</param-name>
-	        <param-value>sesame</param-value>
-	        <description>RDF Store to use</description>
-	    </init-param>
-	    <init-param>
-	        <param-name>repo_url</param-name>
-	        <param-value>http://data.llgc.org.uk/openrdf-sesame/repositories/bor-annotations</param-value>
-	        <description>Set the http URL to use to the Sesame Repository</description>
-	    </init-param>-->
-		<init-param>
-			<param-name>store</param-name>
-		    <param-value>jena</param-value>
-		    <description>RDF Store to use</description>
-		</init-param>
-		<init-param>
-			<param-name>data_dir</param-name>
-		    <param-value>data</param-value>
-		    <description>Sets the directory containing TDB RDF database</description>
-		</init-param>
-	    <!--<init-param>
-	        <param-name>store</param-name>
-	        <param-value>solr</param-value>
-	        <description>Annotation Store to use</description>
-	    </init-param>
-	    <init-param>
-	        <param-name>solr_connection</param-name>
-	        <param-value>http://solr-host/solr/core</param-value>
-	        <description>set the solr connection details</description>
-	    </init-param>-->
-	    <!--<init-param>
-	        <param-name>solr_collection</param-name>
-	        <param-value>annotations</param-value>
-	        <description>The Solr collection to use as an index</description>
-	    </init-param>-->
-		<!--<init-param>
-			<param-name>encoder</param-name>
-		    <param-value>uk.org.llgc.annotation.store.encoders.BookOfPeaceEncoder</param-value>
-		    <description>Changes the Linked data that is stored in the RDF Store. Also decodes it back into a format mirador understands</description>
-		</init-param>-->
-		<!--<init-param>
-			<param-name>baseURI</param-name>
-		    <param-value>http://dev.llgc.org.uk</param-value>
-		    <description>Sets the base uri for the annotation id, either change the above to the public URL to this annotation server or remove it so the server can work out the hostname and port and path from the request.</description>
-		</init-param>-->
-		<load-on-startup>1</load-on-startup> <!-- this needs to be the first one to start -->
-	</servlet>
+    <servlet>
+        <servlet-name>InitServer</servlet-name>
+        <servlet-class>uk.org.llgc.annotation.store.StoreConfig</servlet-class>
+        <!--<init-param>
+            <param-name>store</param-name>
+            <param-value>sesame</param-value>
+            <description>RDF Store to use</description>
+        </init-param>
+        <init-param>
+            <param-name>repo_url</param-name>
+            <param-value>http://data.llgc.org.uk/openrdf-sesame/repositories/bor-annotations</param-value>
+            <description>Set the http URL to use to the Sesame Repository</description>
+        </init-param>-->
+        <init-param>
+            <param-name>store</param-name>
+            <param-value>jena</param-value>
+            <description>RDF Store to use</description>
+        </init-param>
+        <init-param>
+            <param-name>data_dir</param-name>
+            <param-value>data</param-value>
+            <description>Sets the directory containing TDB RDF database</description>
+        </init-param>
+        <!--<init-param>
+            <param-name>store</param-name>
+            <param-value>solr</param-value>
+            <description>Annotation Store to use</description>
+        </init-param>
+        <init-param>
+            <param-name>solr_connection</param-name>
+            <param-value>http://solr-host/solr/core</param-value>
+            <description>set the solr connection details</description>
+        </init-param>-->
+        <!--<init-param>
+            <param-name>solr_collection</param-name>
+            <param-value>annotations</param-value>
+            <description>The Solr collection to use as an index</description>
+        </init-param>-->
+        <!--<init-param>
+            <param-name>encoder</param-name>
+            <param-value>uk.org.llgc.annotation.store.encoders.BookOfPeaceEncoder</param-value>
+            <description>Changes the Linked data that is stored in the RDF Store. Also decodes it back into a format mirador understands</description>
+        </init-param>-->
+        <!--<init-param>
+            <param-name>baseURI</param-name>
+            <param-value>http://dev.llgc.org.uk</param-value>
+            <description>Sets the base uri for the annotation id, either change the above to the public URL to this annotation server or remove it so the server can work out the hostname and port and path from the request.</description>
+        </init-param>-->
+        <load-on-startup>1</load-on-startup> <!-- this needs to be the first one to start -->
+    </servlet>
     <servlet>
         <servlet-name>Search</servlet-name>
         <servlet-class>uk.org.llgc.annotation.store.Search</servlet-class>
@@ -90,15 +90,15 @@
         <servlet-name>ListAllAnnos</servlet-name>
         <servlet-class>uk.org.llgc.annotation.store.ListAnnotations</servlet-class>
     </servlet>
-	 <servlet>
+    <servlet>
         <servlet-name>UploadManifest</servlet-name>
         <servlet-class>uk.org.llgc.annotation.store.ManifestUpload</servlet-class>
-		  <init-param>
-			  <param-name>manifest_dir</param-name>
-			  <param-value>/manifests</param-value>
-		  </init-param>
+        <init-param>
+            <param-name>manifest_dir</param-name>
+            <param-value>/manifests</param-value>
+        </init-param>
     </servlet>
-	 <servlet>
+    <servlet>
         <servlet-name>IIIFSearchAPI</servlet-name>
         <servlet-class>uk.org.llgc.annotation.store.IIIFSearchAPI</servlet-class>
     </servlet>
@@ -110,7 +110,7 @@
         <servlet-name>UploadManifest</servlet-name>
         <url-pattern>/manifests</url-pattern>
     </servlet-mapping>
-	 <servlet-mapping>
+    <servlet-mapping>
         <servlet-name>UploadManifest</servlet-name>
         <url-pattern>/manifests/*</url-pattern>
     </servlet-mapping>
@@ -130,15 +130,15 @@
         <servlet-name>Destroy</servlet-name>
         <url-pattern>/annotation/destroy/*</url-pattern>
     </servlet-mapping>
-	 <servlet-mapping>
+    <servlet-mapping>
         <servlet-name>Populate</servlet-name>
         <url-pattern>/annotation/populate</url-pattern>
     </servlet-mapping>
-	 <servlet-mapping>
+    <servlet-mapping>
         <servlet-name>List</servlet-name>
         <url-pattern>/list.html</url-pattern>
     </servlet-mapping>
-	 <servlet-mapping>
+    <servlet-mapping>
         <servlet-name>ListAllAnnos</servlet-name>
         <url-pattern>/annotation/</url-pattern>
     </servlet-mapping>


### PR DESCRIPTION
Also, the tabs in web.xml have been converted to spaces for consistency.

Maven complained about platform dependence during build, because it assumes the build platform's default character encoding when the character encoding of the Java source files is not explicitly set in the pom.xml file. It produced a warning for the missing version number of the `maven-surefire-plugin` that is used to run the tests. I added a version number for it.