### PR TITLE
Failed populate when annotation has an invalid ID.

### DIFF
--- a/src/main/java/uk/org/llgc/annotation/store/AnnotationUtils.java
+++ b/src/main/java/uk/org/llgc/annotation/store/AnnotationUtils.java
@@ -53,7 +53,7 @@ public class AnnotationUtils {
 	 */
 	public List<Map<String,Object>> readAnnotationList(final InputStream pStream, final String pBaseURL) throws IOException {
 		Object inputList = JsonUtils.fromInputStream(pStream);
-        _logger.debug("Original untouched annotation:");
+        _logger.debug("Original untouched annotation list:");
         _logger.debug(JsonUtils.toPrettyString(inputList));
         List<Map<String,Object>> tAnnotations = null;
         if (inputList instanceof Map) {
@@ -126,6 +126,9 @@ public class AnnotationUtils {
 				_encoder.encode(tAnno);
 			}
 		}
+
+        _logger.debug("Normalised annotation list:");
+        _logger.debug(JsonUtils.toPrettyString(tAnnotations));
 		return tAnnotations;
 	}
     protected String getTarget(final Map<String, Object> pAnno) {
@@ -301,7 +304,7 @@ public class AnnotationUtils {
 		RDFDataMgr.write(tStringOut, pModel, Lang.JSONLD);
         if (pModel.supportsTransactions()) {
             pModel.commit();
-        }    
+        }
 		Map<String,Object> tFramed = (Map<String,Object>)JsonLdProcessor.frame(JsonUtils.fromString(tStringOut.toString()), pFrame,  tOptions);
 
 		Map<String,Object> tJsonLd = (Map<String,Object>)((List)tFramed.get("@graph")).get(0);

--- a/src/main/java/uk/org/llgc/annotation/store/Create.java
+++ b/src/main/java/uk/org/llgc/annotation/store/Create.java
@@ -22,6 +22,8 @@ import uk.org.llgc.annotation.store.adapters.StoreAdapter;
 import uk.org.llgc.annotation.store.encoders.Encoder;
 import uk.org.llgc.annotation.store.exceptions.IDConflictException;
 
+import java.net.URISyntaxException;
+
 public class Create extends HttpServlet {
 	protected static Logger _logger = LogManager.getLogger(Create.class.getName()); 
 	protected AnnotationUtils _annotationUtils = null;
@@ -60,6 +62,11 @@ public class Create extends HttpServlet {
 			pRes.setStatus(HttpServletResponse.SC_BAD_REQUEST);
 			pRes.setContentType("text/plain");
 			pRes.getOutputStream().println("Failed to load annotation due to conflict in ID: " + tException.toString());
+        } catch (URISyntaxException tException) {    
+			tException.printStackTrace();
+			pRes.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+			pRes.setContentType("text/plain");
+			pRes.getOutputStream().println("Failed to load annotation due to invalid annotation ID:" + tException.toString());
 		} catch (IOException tException) {	
 			System.err.println("Exception occured trying to add annotation:");
 			tException.printStackTrace();

--- a/src/main/java/uk/org/llgc/annotation/store/Populate.java
+++ b/src/main/java/uk/org/llgc/annotation/store/Populate.java
@@ -25,6 +25,7 @@ import org.apache.jena.rdf.model.Model;
 import uk.org.llgc.annotation.store.adapters.StoreAdapter;
 import uk.org.llgc.annotation.store.encoders.Encoder;
 import uk.org.llgc.annotation.store.exceptions.IDConflictException;
+import java.net.URISyntaxException;
 
 public class Populate extends HttpServlet {
 	protected static Logger _logger = LogManager.getLogger(Populate.class.getName()); 
@@ -69,6 +70,12 @@ public class Populate extends HttpServlet {
 			pRes.setStatus(HttpServletResponse.SC_BAD_REQUEST);
 			pRes.setContentType("text/plain");
 			pRes.getOutputStream().println("Failed to load annotation list as there was a conflict in ids " + tException.toString());
+        } catch (URISyntaxException tException) {
+			tException.printStackTrace();
+			pRes.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+			pRes.setContentType("text/plain");
+			pRes.getOutputStream().println("Annotation was malformed: " + tException.toString());
+
 		}
 	}
 }

--- a/src/main/java/uk/org/llgc/annotation/store/adapters/AbstractRDFStore.java
+++ b/src/main/java/uk/org/llgc/annotation/store/adapters/AbstractRDFStore.java
@@ -40,6 +40,7 @@ import org.apache.jena.query.ResultSet;
 
 public abstract class AbstractRDFStore extends AbstractStoreAdapter {
 	protected static Logger _logger = LogManager.getLogger(AbstractRDFStore.class.getName());
+
 	public List<Model> getAnnotationsFromPage(final String pPageId) throws IOException {
 		String tQueryString = "select ?annoId ?graph where {"
 										+ " GRAPH ?graph { ?on <http://www.w3.org/ns/oa#hasSource> <" + pPageId + "> ."
@@ -259,7 +260,7 @@ public abstract class AbstractRDFStore extends AbstractStoreAdapter {
 									 "GRAPH ?graph {?anno rdf:type <http://www.w3.org/ns/oa#Annotation> . " +
 								    "FILTER NOT EXISTS {?canvas rdf:first ?anno} " +
 							 	    "}}";
-
+        _logger.debug("Running SPARQL: " + tQueryString);
 		QueryExecution tExec = this.getQueryExe(tQueryString);
 
 		this.begin(ReadWrite.READ);
@@ -275,10 +276,11 @@ public abstract class AbstractRDFStore extends AbstractStoreAdapter {
 
 		try {
 			if (results != null) {
+                _logger.debug("Searching for results");
 				while (results.hasNext()) {
 					QuerySolution soln = results.nextSolution() ;
 					Resource tAnnoURI = soln.getResource("anno") ; // Get a result variable - must be a resource
-
+                    _logger.debug("Found + " + tAnnoURI.getURI());
 					Model tAnno = this.getNamedModel(tAnnoURI.getURI());
 
 					Map<String,Object> tJsonAnno = _annoUtils.frameAnnotation(tAnno, false);

--- a/src/main/java/uk/org/llgc/annotation/store/adapters/JenaStore.java
+++ b/src/main/java/uk/org/llgc/annotation/store/adapters/JenaStore.java
@@ -39,8 +39,11 @@ public class JenaStore extends AbstractRDFStore implements StoreAdapter {
 	public Model addAnnotationSafe(final Map<String,Object> pJson) throws IOException {
 		String tJson = JsonUtils.toString(pJson);
 
+        _logger.debug("Converting: " + tJson);
 		Model tJsonLDModel = ModelFactory.createDefaultModel();
+
 		RDFDataMgr.read(tJsonLDModel, new ByteArrayInputStream(tJson.getBytes(Charset.forName("UTF-8"))), Lang.JSONLD);
+
 		_dataset.begin(ReadWrite.WRITE) ;
 		_dataset.addNamedModel((String)pJson.get("@id"), tJsonLDModel);
 		_dataset.commit();

--- a/src/main/java/uk/org/llgc/annotation/store/adapters/StoreAdapter.java
+++ b/src/main/java/uk/org/llgc/annotation/store/adapters/StoreAdapter.java
@@ -33,15 +33,17 @@ import java.io.File;
 
 import com.github.jsonldjava.utils.JsonUtils;
 
+import java.net.URISyntaxException;
+
 import java.nio.charset.Charset;
 
 public interface StoreAdapter {
 
 	public void init(final AnnotationUtils pAnnoUtils);
-	public Model addAnnotation(final Map<String,Object> pJson) throws IOException, IDConflictException;
+	public Model addAnnotation(final Map<String,Object> pJson) throws IOException, IDConflictException, URISyntaxException;
 	public Model updateAnnotation(final Map<String,Object> pJson) throws IOException;
 
-	public List<Model> addAnnotationList(final List<Map<String,Object>> pJson) throws IOException, IDConflictException;
+	public List<Model> addAnnotationList(final List<Map<String,Object>> pJson) throws IOException, IDConflictException, URISyntaxException;
 
 	public String indexManifest(Map<String,Object> pManifest) throws IOException;
 	public List<String> getManifests() throws IOException;

--- a/src/test/java/uk/org/llgc/annotation/store/test/TestBOR.java
+++ b/src/test/java/uk/org/llgc/annotation/store/test/TestBOR.java
@@ -39,6 +39,8 @@ import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.query.* ;
 
+import java.net.URISyntaxException;
+
 public class TestBOR extends TestUtils {
 	protected static Logger _logger = LogManager.getLogger(TestBOR.class.getName()); 
 
@@ -57,7 +59,7 @@ public class TestBOR extends TestUtils {
 	}
 
 	@Test
-	public void testAnnotation() throws IOException, IDConflictException {
+	public void testAnnotation() throws IOException, IDConflictException, URISyntaxException {
 		_logger.debug("Reading annotation");
 		Map<String, Object> tAnnotationJSON = _annotationUtils.readAnnotaion(new FileInputStream(getClass().getResource("/jsonld/borAnnotation.json").getFile()), StoreConfig.getConfig().getBaseURI(null)); 
 
@@ -97,7 +99,7 @@ public class TestBOR extends TestUtils {
 	}
 
 	@Test
-	public void testRetrieveAnnotation() throws IOException, IDConflictException {
+	public void testRetrieveAnnotation() throws IOException, IDConflictException, URISyntaxException {
 		_logger.debug("Reading annotation");
 		Map<String, Object> tAnnotationJSON = _annotationUtils.readAnnotaion(new FileInputStream(getClass().getResource("/jsonld/borAnnotation.json").getFile()), StoreConfig.getConfig().getBaseURI(null)); 
 
@@ -119,7 +121,7 @@ public class TestBOR extends TestUtils {
 	}
 
 	@Test
-	public void testAberAnno() throws IOException, IDConflictException {
+	public void testAberAnno() throws IOException, IDConflictException, URISyntaxException {
 		Map<String, Object> tAnnotationJSON = _annotationUtils.readAnnotaion(new FileInputStream(getClass().getResource("/jsonld/aberAnnotation.json").getFile()), StoreConfig.getConfig().getBaseURI(null)); 
 
 		Model tModel = _store.addAnnotation(tAnnotationJSON);

--- a/src/test/java/uk/org/llgc/annotation/store/test/TestMirador2.java
+++ b/src/test/java/uk/org/llgc/annotation/store/test/TestMirador2.java
@@ -46,6 +46,8 @@ import org.openrdf.repository.RepositoryException;
 
 import java.util.Properties;
 
+import java.net.URISyntaxException;
+
 public class TestMirador2 extends TestUtils {
 	protected static Logger _logger = LogManager.getLogger(TestMirador2.class.getName());
 
@@ -64,7 +66,7 @@ public class TestMirador2 extends TestUtils {
 	}
 
 	@Test
-	public void TestMirador2() throws IOException, IDConflictException, InterruptedException {
+	public void TestMirador2() throws IOException, IDConflictException, InterruptedException, URISyntaxException {
 		Map<String, Object> tAnnotationJSON = _annotationUtils.readAnnotaion(new FileInputStream(getClass().getResource("/jsonld/testAnnotation.json").getFile()), StoreConfig.getConfig().getBaseURI(null));
 
 		String tAnnoId = (String)tAnnotationJSON.get("@id");
@@ -81,7 +83,7 @@ public class TestMirador2 extends TestUtils {
 	}
 
     @Test
-    public void testPopulate() throws IOException, IDConflictException, InterruptedException {
+    public void testPopulate() throws IOException, IDConflictException, InterruptedException, URISyntaxException {
         List<Map<String, Object>> tAnnotationListJSON = _annotationUtils.readAnnotationList(new FileInputStream(getClass().getResource("/jsonld/annos_master_version1.json").getFile()), StoreConfig.getConfig().getBaseURI(null)); //annotaiton list
 
         List<Model> tModel = _store.addAnnotationList(tAnnotationListJSON);

--- a/src/test/java/uk/org/llgc/annotation/store/test/TestMirador214.java
+++ b/src/test/java/uk/org/llgc/annotation/store/test/TestMirador214.java
@@ -46,6 +46,8 @@ import org.openrdf.repository.RepositoryException;
 
 import java.util.Properties;
 
+import java.net.URISyntaxException;
+
 public class TestMirador214 extends TestUtils {
 	protected static Logger _logger = LogManager.getLogger(TestMirador214.class.getName());
 
@@ -64,7 +66,7 @@ public class TestMirador214 extends TestUtils {
 	}
 
 	@Test
-	public void testMirador214() throws IOException, IDConflictException, InterruptedException {
+	public void testMirador214() throws IOException, IDConflictException, InterruptedException, URISyntaxException {
 		Map<String, Object> tAnnotationJSON = _annotationUtils.readAnnotaion(new FileInputStream(getClass().getResource("/jsonld/mirador-2.1.4.json").getFile()), StoreConfig.getConfig().getBaseURI(null));
 
 		String tAnnoId = (String)tAnnotationJSON.get("@id");

--- a/src/test/java/uk/org/llgc/annotation/store/test/TestPublish.java
+++ b/src/test/java/uk/org/llgc/annotation/store/test/TestPublish.java
@@ -45,6 +45,8 @@ import org.openrdf.repository.RepositoryException;
 
 import java.util.Properties;
 
+import java.net.URISyntaxException;
+
 public class TestPublish extends TestUtils {
 	protected static Logger _logger = LogManager.getLogger(TestPublish.class.getName());
 
@@ -63,7 +65,7 @@ public class TestPublish extends TestUtils {
 	}
 
 	@Test
-	public void testPublish() throws IOException, IDConflictException {
+	public void testPublish() throws IOException, IDConflictException, URISyntaxException {
 		List<Map<String, Object>> tAnnotationListJSON = _annotationUtils.readAnnotationList(new FileInputStream(getClass().getResource("/jsonld/testAnnotationList1.json").getFile()), StoreConfig.getConfig().getBaseURI(null)); //annotaiton list
 
 		List<Model> tAnnosAsModel = _store.addAnnotationList(tAnnotationListJSON);
@@ -90,7 +92,7 @@ public class TestPublish extends TestUtils {
 
 
 	@Test
-	public void testCreate() throws IOException, IDConflictException {
+	public void testCreate() throws IOException, IDConflictException, URISyntaxException {
 		Map<String, Object> tAnnotationJSON = _annotationUtils.readAnnotaion(new FileInputStream(getClass().getResource("/jsonld/testAnnotation.json").getFile()), StoreConfig.getConfig().getBaseURI(null));
 
 		Model tModel = _store.addAnnotation(tAnnotationJSON);
@@ -101,7 +103,7 @@ public class TestPublish extends TestUtils {
 
 	// test reuse of id
 	@Test
-	public void testDelete() throws IOException, IDConflictException {
+	public void testDelete() throws IOException, IDConflictException, URISyntaxException {
 		Map<String, Object> tAnnotationJSON = _annotationUtils.readAnnotaion(new FileInputStream(getClass().getResource("/jsonld/testAnnotation.json").getFile()), StoreConfig.getConfig().getBaseURI(null));
 
 		Model tModel = _store.addAnnotation(tAnnotationJSON);
@@ -113,7 +115,7 @@ public class TestPublish extends TestUtils {
 	}
 
 	@Test
-	public void testUpdate() throws IOException, IDConflictException {
+	public void testUpdate() throws IOException, IDConflictException, URISyntaxException {
 		Map<String, Object> tAnnotationJSON = _annotationUtils.readAnnotaion(new FileInputStream(getClass().getResource("/jsonld/testAnnotation.json").getFile()), StoreConfig.getConfig().getBaseURI(null));
 
 		Model tModel = _store.addAnnotation(tAnnotationJSON);
@@ -128,7 +130,7 @@ public class TestPublish extends TestUtils {
 	}
 
 	@Test
-	public void testPage() throws IOException, IDConflictException {
+	public void testPage() throws IOException, IDConflictException, URISyntaxException {
 		List<Map<String, Object>> tAnnotationList = _annotationUtils.readAnnotationList(new FileInputStream(getClass().getResource("/jsonld/testAnnotationList2.json").getFile()), StoreConfig.getConfig().getBaseURI(null));
 
 		for (Map<String,Object> tAnnotation : tAnnotationList) {
@@ -148,7 +150,7 @@ public class TestPublish extends TestUtils {
 	}
 
 	@Test
-	public void testUTF8() throws IOException, IDConflictException {
+	public void testUTF8() throws IOException, IDConflictException, URISyntaxException {
 		Map<String, Object> tAnnotationJSON = _annotationUtils.readAnnotaion(new FileInputStream(getClass().getResource("/jsonld/utf-8.json").getFile()), StoreConfig.getConfig().getBaseURI(null));
 
 		Model tModel = _store.addAnnotation(tAnnotationJSON);
@@ -159,7 +161,7 @@ public class TestPublish extends TestUtils {
 
 	//@Test(expected=IDConflictException.class)
 	@Test
-	public void testDuplicate() throws IOException, IDConflictException, InterruptedException {
+	public void testDuplicate() throws IOException, IDConflictException, InterruptedException, URISyntaxException {
 		Map<String, Object> tAnnotationJSON = _annotationUtils.readAnnotaion(new FileInputStream(getClass().getResource("/jsonld/testAnnotationId.json").getFile()), StoreConfig.getConfig().getBaseURI(null));
 		Map<String, Object> tAnnotationJSON2 = _annotationUtils.readAnnotaion(new FileInputStream(getClass().getResource("/jsonld/testAnnotationId.json").getFile()), StoreConfig.getConfig().getBaseURI(null));
 
@@ -173,7 +175,7 @@ public class TestPublish extends TestUtils {
 	}
 
 	@Test
-	public void testDates() throws IOException, IDConflictException, InterruptedException {
+	public void testDates() throws IOException, IDConflictException, InterruptedException, URISyntaxException {
 		Map<String, Object> tAnnotationJSON = _annotationUtils.readAnnotaion(new FileInputStream(getClass().getResource("/jsonld/testAnnotation.json").getFile()), StoreConfig.getConfig().getBaseURI(null));
 
 		String tAnnoId = (String)tAnnotationJSON.get("@id");

--- a/src/test/java/uk/org/llgc/annotation/store/test/TestSearch.java
+++ b/src/test/java/uk/org/llgc/annotation/store/test/TestSearch.java
@@ -103,7 +103,7 @@ public class TestSearch extends TestUtils {
 	}
 
 	@Test
-	public void testPassedWithin() throws IOException, IDConflictException {
+	public void testPassedWithin() throws IOException, IDConflictException, URISyntaxException {
 		Map<String, Object> tAnnotationJSON = _annotationUtils.readAnnotaion(new FileInputStream(getClass().getResource("/jsonld/testManifestWithin.json").getFile()), StoreConfig.getConfig().getBaseURI(null));
 		Model tModel = _store.addAnnotation(tAnnotationJSON);
 		List<String> tWithin = this.getWithin(tModel, "http://example.com/manifest/annotation/within");
@@ -117,7 +117,7 @@ public class TestSearch extends TestUtils {
 	}
 
 	@Test
-	public void loadManifest() throws IOException, IDConflictException {
+	public void loadManifest() throws IOException, IDConflictException, URISyntaxException {
 		Map<String, Object> tAnnotationJSON = _annotationUtils.readAnnotaion(new FileInputStream(getClass().getResource("/jsonld/testManifestAnno1.json").getFile()), StoreConfig.getConfig().getBaseURI(null));
 		Model tModel = _store.addAnnotation(tAnnotationJSON);
 		// check no within
@@ -155,7 +155,7 @@ public class TestSearch extends TestUtils {
 	}
 
 	@Test
-	public void testSearching() throws IOException, IDConflictException {
+	public void testSearching() throws IOException, IDConflictException, URISyntaxException {
         // Add two copies of the same annotation list but pointing to different Manifests
         // this checks if the scoping to manifest search is working.
 		List<Map<String, Object>> tAnnotationListJSON = _annotationUtils.readAnnotationList(new FileInputStream(getClass().getResource("/jsonld/testAnnotationListSearch-distraction.json").getFile()), StoreConfig.getConfig().getBaseURI(null)); //annotaiton list
@@ -196,7 +196,7 @@ public class TestSearch extends TestUtils {
 	}
 
     @Test
-	public void testMirador() throws IOException, IDConflictException {
+	public void testMirador() throws IOException, IDConflictException, URISyntaxException {
 		List<Map<String, Object>> tAnnotationListJSON = _annotationUtils.readAnnotationList(new FileInputStream(getClass().getResource("/jsonld/testAnnotationListSearch.json").getFile()), StoreConfig.getConfig().getBaseURI(null)); //annotaiton list
 
 		_store.addAnnotationList(tAnnotationListJSON);
@@ -215,6 +215,26 @@ public class TestSearch extends TestUtils {
         assertTrue("Mirador requires resource to be an object. Found class " + tAnno.get("resource").getClass().getName(), tAnno.get("resource") instanceof Map);
 		assertNotNull("Mirador requires a label describing a search match, using annotation.label", tAnno.get("label"));
     }
+
+    @Test(expected = URISyntaxException.class)
+    public void testInvalidAnnoId() throws IOException, IDConflictException, URISyntaxException {
+        // Add two copies of the same annotation list but pointing to different Manifests
+        // this checks if the scoping to manifest search is working.
+        Map<String,Object> tAnnoListRaw = (Map<String,Object>)JsonUtils.fromInputStream(new FileInputStream(getClass().getResource("/jsonld/populateAnno.json").getFile()));
+        String tOriginalAnnoId = (String)((List<Map<String,Object>>)tAnnoListRaw.get("resources")).get(0).get("@id");
+
+        List<Map<String, Object>> tAnnotationListJSON = _annotationUtils.readAnnotationList(new FileInputStream(getClass().getResource("/jsonld/populateAnno.json").getFile()), StoreConfig.getConfig().getBaseURI(null)); //annotaiton list
+        try {
+            List<Model> tModels = _store.addAnnotationList(tAnnotationListJSON); // this should throw Exception as Anno ID isn't a valid URI
+
+            String tId = (String)tAnnotationListJSON.get(0).get("@id");
+            assertEquals("Annotation ID changed on loading... ", tOriginalAnnoId, tId);
+        } catch (Exception tExcpt) {
+            tExcpt.printStackTrace();
+            throw tExcpt;
+        }
+    }
+
 
 	@Test
 	public void testPagination() throws IOException, IDConflictException, URISyntaxException, ParseException {

--- a/src/test/resources/jsonld/populateAnno.json
+++ b/src/test/resources/jsonld/populateAnno.json
@@ -1,0 +1,19 @@
+{
+    "@context": "http://iiif.io/api/presentation/2/context.json",
+    "@id": "http://invalid_anno_id",
+    "@type": "sc:AnnotationList",
+    "resources": [
+        {
+            "@id": "84fd0328-5041-488e-9efc-4e49c954b93e",
+            "@type": "oa:Annotation",
+            "created": "2018-01-23 09:54:08+00:00",
+            "motivation": "sc:painting",
+            "on": "https://damsssl.llgc.org.uk/iiif/2.0/4078677/canvas/4078678.json#xywh=0,0,3596,5641",
+            "resource": {
+                "@type": "cnt:ContentAsText",
+                "chars": "Annotation text",
+                "format": "text/plain"
+            }
+        }
+    ]
+}

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -33,6 +33,9 @@
         <Logger name="uk.org.llgc.annotation.store.StoreConfig" level="INFO" additivity="false">
 			<AppenderRef ref="Console"/>
 		</Logger>
+        <Logger name="uk.org.llgc.annotation" level="info" additivity="false">
+			<AppenderRef ref="Console"/>
+		</Logger>
         <Logger name="org.apache.jena.info" level="INFO" additivity="false">
 	        <AppenderRef ref="Console"/>
 	    </Logger>


### PR DESCRIPTION
It used to fail silently if a annotation was submitted that didn't have a valid ID and specifically a missing scheme in the URI. 