### PR TITLE
Update Solr and Tomcat docs

### DIFF
--- a/doc/Solr.md
+++ b/doc/Solr.md
@@ -1,4 +1,4 @@
-Setting up SOLR as an annotation store
+# Setting up SOLR as an annotation store
 
 Download SOLR from:
 
@@ -62,13 +62,13 @@ mvn jetty:run
 Start SOLR:
 
 ```
- ./bin/solr -e cloud -noprompt
- ```
+./bin/solr -e cloud -noprompt
+```
 
- Load annotations:
+Load annotations:
 
- ```
- # cp config from SAS:
- cp -r $SAS_HOME/src/main/resources/solr $SOLR_HOME/server/solr/configsets/annos
- ./bin/solr create_collection -c test -d server/solr/configsets/annos -shards 2
- ```
+```
+# cp config from SAS:
+cp -r $SAS_HOME/src/main/resources/solr $SOLR_HOME/server/solr/configsets/annos
+./bin/solr create_collection -c test -d server/solr/configsets/annos -shards 2
+```

--- a/doc/tomcat.md
+++ b/doc/tomcat.md
@@ -1,13 +1,13 @@
 # Deploying to Tomcat
 
-Edit the location of the Jena data dir as by default it will create it in $TOMCAT_HOME/data. Edit [sas.properties](../src/main/webapp/WEB-INF/sas.properties) and change the following:
+Edit the location of the Jena data dir as by default it will create it in `$TOMCAT_HOME/data`. Edit [sas.properties](../src/main/webapp/WEB-INF/sas.properties) and change the following:
 
 ```
 # Uncomment this if you would like to use Jena as a backend
 store=jena
 data_dir=data
 ```
-change the param-value to something like /usr/local/annotation-data.
+Change the value of `data_dir` to something like `/usr/local/annotation-data`.
 
 Create a war file:
 
@@ -15,6 +15,6 @@ Create a war file:
 mvn package
 ```
 
-copy SimpleAnnotationServer/target/simpleAnnotationStore.war to your tomcat webapps directory. You should now be able to access it at:
+Copy `SimpleAnnotationServer/target/simpleAnnotationStore.war` to your Tomcat webapps directory. You should now be able to access it at:
 
-http://host:port/SimpleAnnotationServer/index.html
+http://host:port/simpleAnnotationStore/index.html


### PR DESCRIPTION
Some layout/markup updates, but in the Tomcat doc the URL has been updated to
match the WAR file. If the WAR file is `simpleAnnotationStore.war`,
that will be in the URL.

(This is my fifth Hacktoberfest PR, so further documentation PRs may come but not today.)