### PR TITLE
Add JSON-LD frame option to prune blank node IDs

### DIFF
--- a/src/main/java/uk/org/llgc/annotation/store/AnnotationUtils.java
+++ b/src/main/java/uk/org/llgc/annotation/store/AnnotationUtils.java
@@ -302,6 +302,7 @@ public class AnnotationUtils {
 
 		final JsonLdOptions tOptions = new JsonLdOptions();
 		tOptions.format = "application/jsonld";
+		tOptions.setPruneBlankNodeIdentifiers(true);
 
 		StringWriter tStringOut = new StringWriter();
         if (pModel.supportsTransactions()) {


### PR DESCRIPTION
This fixes #48 (tested on my machine with `mvn jetty:run`) by instructing the JSON-LD framing code to prune (i.e. remove) blank node identifiers.